### PR TITLE
Add SQLite as database provider for cloud file-based storage

### DIFF
--- a/docker/compose.api-sqlite.yml
+++ b/docker/compose.api-sqlite.yml
@@ -1,0 +1,35 @@
+# API service with SQLite - no SQL Server needed for API database
+#
+# Usage (slim base): docker compose -f compose.base-sqlite.yml -f compose.idp.yml -f compose.api-sqlite.yml up -d
+# Usage (full base): docker compose -f compose.base.yml -f compose.idp.yml -f compose.api-sqlite.yml up -d
+#
+# The SQLite database file is saved to ./data/ on the host (bind mount).
+# Point this to a cloud sync folder for automatic backup:
+#   volumes:
+#     - C:/Users/name/OneDrive/hmm-data:/app/data
+
+services:
+  hmm-api:
+    build:
+      context: ..
+      dockerfile: src/Hmm.ServiceApi/Dockerfile
+    container_name: hmm-api
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Docker
+      - ASPNETCORE_URLS=http://+:80
+      - ConnectionStrings__DefaultConnection=Data Source=/app/data/hmm.db
+      - AppSettings__DatabaseProvider=SQLite
+      - AppSettings__IdpBaseUrl=http://hmm-idp:80
+      - Serilog__WriteTo__0__Args__serverUrl=http://seq:5341
+    ports:
+      - "${API_HTTP_PORT}:80"
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      seq:
+        condition: service_started
+      hmm-idp:
+        condition: service_started
+    networks:
+      - hmm-network
+    restart: unless-stopped

--- a/docker/compose.base-sqlite.yml
+++ b/docker/compose.base-sqlite.yml
@@ -1,0 +1,50 @@
+# Slim infrastructure for SQLite API setup - no api-sqlserver needed
+#
+# Scenario 1 (API local):    docker compose -f compose.base-sqlite.yml -f compose.idp.yml up -d
+# Scenario 2 (all Docker):   docker compose -f compose.base-sqlite.yml -f compose.idp.yml -f compose.api-sqlite.yml up -d
+# Scenario 3 (API+IDP local): docker compose -f compose.base-sqlite.yml up -d
+
+services:
+  idp-sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: hmm-idp-sqlserver
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: ${IDP_SA_PASSWORD}
+      MSSQL_PID: "Developer"
+    ports:
+      - "${IDP_SQLSERVER_PORT}:1433"
+    volumes:
+      - idp-sqlserver-data:/var/opt/mssql
+    networks:
+      - hmm-network
+    healthcheck:
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${IDP_SA_PASSWORD}" -C -Q "SELECT 1" || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+  seq:
+    image: datalust/seq:latest
+    container_name: hmm-seq
+    environment:
+      ACCEPT_EULA: "Y"
+      SEQ_FIRSTRUN_NOAUTHENTICATION: "true"
+    ports:
+      - "${SEQ_INGESTION_PORT}:5341"
+      - "${SEQ_UI_PORT}:80"
+    volumes:
+      - seq-data:/data
+    networks:
+      - hmm-network
+    restart: unless-stopped
+
+networks:
+  hmm-network:
+    driver: bridge
+
+volumes:
+  idp-sqlserver-data:
+  seq-data:

--- a/src/Hmm.Core.Dal.EF/Hmm.Core.Dal.EF.csproj
+++ b/src/Hmm.Core.Dal.EF/Hmm.Core.Dal.EF.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.1" />

--- a/src/Hmm.Core.Dal.EF/HmmDataContext.cs
+++ b/src/Hmm.Core.Dal.EF/HmmDataContext.cs
@@ -57,6 +57,7 @@ namespace Hmm.Core.Dal.EF
         {
             try
             {
+                UpdateSqliteVersionTokens();
                 return base.SaveChanges();
             }
             catch (Exception ex)
@@ -70,11 +71,26 @@ namespace Hmm.Core.Dal.EF
         {
             try
             {
+                UpdateSqliteVersionTokens();
                 return await base.SaveChangesAsync(cancellationToken);
             }
             catch (Exception ex)
             {
                 throw new DataSourceException(ex.Message, ex);
+            }
+        }
+
+        private void UpdateSqliteVersionTokens()
+        {
+            if (Database.ProviderName?.Contains("Sqlite", StringComparison.OrdinalIgnoreCase) != true)
+                return;
+
+            foreach (var entry in ChangeTracker.Entries<VersionedEntity>())
+            {
+                if (entry.State == EntityState.Added || entry.State == EntityState.Modified)
+                {
+                    entry.Entity.Version = Guid.NewGuid().ToByteArray();
+                }
             }
         }
 
@@ -90,6 +106,7 @@ namespace Hmm.Core.Dal.EF
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             var isPostgres = Database.ProviderName?.Contains("Npgsql", StringComparison.OrdinalIgnoreCase) == true;
+            var isSqlite = Database.ProviderName?.Contains("Sqlite", StringComparison.OrdinalIgnoreCase) == true;
 
             if (isPostgres)
             {
@@ -128,15 +145,27 @@ namespace Hmm.Core.Dal.EF
             modelBuilder.Entity<HmmNoteDao>().HasKey(n => n.Id);
 
             // Configure Version property differently based on provider
-            var versionProperty = modelBuilder.Entity<HmmNoteDao>()
-                .Property(n => n.Version)
-                .HasColumnName("ts")
-                .IsConcurrencyToken()
-                .ValueGeneratedOnAddOrUpdate();
-
-            if (isPostgres)
+            if (isSqlite)
             {
-                versionProperty.HasColumnType("bytea");
+                modelBuilder.Entity<HmmNoteDao>()
+                    .Property(n => n.Version)
+                    .HasColumnName("ts")
+                    .HasColumnType("BLOB")
+                    .IsConcurrencyToken()
+                    .ValueGeneratedNever();
+            }
+            else
+            {
+                var versionProperty = modelBuilder.Entity<HmmNoteDao>()
+                    .Property(n => n.Version)
+                    .HasColumnName("ts")
+                    .IsConcurrencyToken()
+                    .ValueGeneratedOnAddOrUpdate();
+
+                if (isPostgres)
+                {
+                    versionProperty.HasColumnType("bytea");
+                }
             }
 
             // FK to Author with explicit constraint name and index (Issue #25 fix)
@@ -188,6 +217,13 @@ namespace Hmm.Core.Dal.EF
             if (isPostgres)
             {
                 catalogEntity.Property(e => e.Schema).HasColumnType("xml");
+            }
+
+            if (isSqlite)
+            {
+                modelBuilder.Entity<NoteCatalogDao>()
+                    .Property(e => e.FormatType)
+                    .HasConversion<int>();
             }
 
             // ============================================================

--- a/src/Hmm.ServiceApi/Configuration/AppSettings.cs
+++ b/src/Hmm.ServiceApi/Configuration/AppSettings.cs
@@ -5,7 +5,7 @@ public class AppSettings
     public string ConnectionString { get; set; }
 
     /// <summary>
-    /// Database provider: "SqlServer" (default) or "PostgreSQL"
+    /// Database provider: "SqlServer" (default), "PostgreSQL", or "SQLite"
     /// </summary>
     public string DatabaseProvider { get; set; } = "SqlServer";
 

--- a/src/Hmm.ServiceApi/Startup.cs
+++ b/src/Hmm.ServiceApi/Startup.cs
@@ -108,20 +108,24 @@ namespace Hmm.ServiceApi
             });
 
             // Configure database provider based on AppSettings.DatabaseProvider
-            // Default is SQL Server; set to "PostgreSQL" to use PostgreSQL
+            // Default is SQL Server; set to "PostgreSQL" or "SQLite" for alternatives
             var connectionString = Configuration.GetConnectionString("HmmNoteConnection")
                                    ?? Configuration.GetConnectionString("DefaultConnection");
-            var usePostgres = string.Equals(appSetting?.DatabaseProvider, "PostgreSQL", StringComparison.OrdinalIgnoreCase);
+            var databaseProvider = appSetting?.DatabaseProvider ?? "SqlServer";
 
             services.AddDbContext<HmmDataContext>(opt =>
                 {
-                    if (usePostgres)
+                    if (string.Equals(databaseProvider, "PostgreSQL", StringComparison.OrdinalIgnoreCase))
                     {
                         // PostgreSQL with Npgsql
                         var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionString);
                         dataSourceBuilder.MapEnum<Core.Map.DbEntity.NoteContentFormatType>();
                         var dataSource = dataSourceBuilder.Build();
                         opt.UseNpgsql(dataSource);
+                    }
+                    else if (string.Equals(databaseProvider, "SQLite", StringComparison.OrdinalIgnoreCase))
+                    {
+                        opt.UseSqlite(connectionString);
                     }
                     else
                     {
@@ -219,6 +223,17 @@ namespace Hmm.ServiceApi
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UseExceptionHandler(_ => { });
+
+            // SQLite: auto-create database and enable WAL mode for cloud sync friendliness
+            using (var scope = app.ApplicationServices.CreateScope())
+            {
+                var dbContext = scope.ServiceProvider.GetRequiredService<HmmDataContext>();
+                if (dbContext.Database.ProviderName?.Contains("Sqlite", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    dbContext.Database.EnsureCreated();
+                    dbContext.Database.ExecuteSqlRaw("PRAGMA journal_mode=WAL;");
+                }
+            }
 
             if (env.IsDevelopment() || env.EnvironmentName == "Docker")
             {

--- a/src/Hmm.ServiceApi/appsettings.SQLite.json
+++ b/src/Hmm.ServiceApi/appsettings.SQLite.json
@@ -1,0 +1,8 @@
+{
+  "AppSettings": {
+    "DatabaseProvider": "SQLite"
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=hmm.db"
+  }
+}


### PR DESCRIPTION
## Summary
- Add SQLite as a third database provider alongside SQL Server and PostgreSQL, enabling low-cost cloud file-based persistence for single-user deployment
- Handle SQLite-specific model configuration: app-managed concurrency tokens (`ValueGeneratedNever` + GUID-based versioning), enum-to-int conversion for `NoteContentFormatType`
- Add Docker Compose overlays (`compose.base-sqlite.yml`, `compose.api-sqlite.yml`) that eliminate the `api-sqlserver` container, with bind mount for host-accessible `.db` file

## Test plan
- [x] `dotnet build Hmm.sln` - 0 errors, 0 warnings
- [x] `dotnet test Hmm.sln` - all tests pass (3 pre-existing failures unrelated to this change)
- [x] Docker Scenario 2 verified: all containers start, SQLite database auto-created with WAL mode
- [x] Schema validated: all 6 tables, foreign keys, unique constraints, and indexes created correctly
- [x] CRUD operations verified via sqlite3 CLI with JOIN queries across all tables
- [x] Constraint enforcement verified: unique, foreign key violations correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)